### PR TITLE
12 make sure only images could be uploaded and not any file type

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -34,8 +34,6 @@ jobs:
         ports:
           - 9000:9000
           - 9001:9001  
-        options: --health-cmd="curl --silent --fail http://localhost:9000/minio/health/live"  # Health check using liveness probe
-
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -28,15 +28,13 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       minio:
         image: minio/minio:latest
-        options: --entrypoint /bin/sh -c "minio server --console-address ':9001' /data"
-        ports:
-          - 9000:9000  # MinIO API port
-          - 9001:9001  # MinIO Console port
         env:
           MINIO_ROOT_USER: minioadmin
           MINIO_ROOT_PASSWORD: minioadmin
-        volumes:
-          - minio-data:/data
+        ports:
+          - 9000:9000
+          - 9001:9001  
+        options: --health-cmd "curl --silent --fail http://localhost:9000/minio/health/live" --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v4
       
@@ -61,6 +59,8 @@ jobs:
       - name: Run tests with Pytest
         env:
           DATABASE_URL: postgresql+asyncpg://user:password@localhost:5432/myappdb  # Configure the DATABASE_URL environment variable for tests
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minioadmin
           MINIO_URL: "http://minio:9000"  # Set the MinIO service URL to communicate with it in the test environment
 
         run: pytest

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -57,7 +57,7 @@ jobs:
           
       - name: Run tests with Pytest
         env:
-          minio_host: "localhost:9000"  
+          # minio_host: "localhost:9000"  
           DATABASE_URL: postgresql+asyncpg://user:password@localhost:5432/myappdb  # Configure the DATABASE_URL environment variable for tests
         run: pytest
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -28,7 +28,6 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       minio:
         image: minio/minio:latest
-        command: server /data --console-address ":9001"  # Starts the MinIO server and console on port 9001
         env:
           MINIO_ACCESS_KEY: minioadmin
           MINIO_SECRET_KEY: minioadmin
@@ -38,9 +37,6 @@ jobs:
         volumes:
           - minio-data:/data  # Mount volume for data persistence
         options: --health-cmd "curl --silent --fail http://localhost:9000/minio/health/ready" --health-interval 10s --health-timeout 5s --health-retries 5
-        # Ensure that the MinIO service is healthy before running tests
-        networks:
-          - app-network
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -28,15 +28,15 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       minio:
         image: minio/minio:latest
-        env:
-          MINIO_ACCESS_KEY: minioadmin
-          MINIO_SECRET_KEY: minioadmin
+        options: --entrypoint /bin/sh -c "minio server --console-address ':9001' /data"
         ports:
           - 9000:9000  # MinIO API port
-          - 9001:9001  # MinIO web console port
+          - 9001:9001  # MinIO Console port
+        env:
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minioadmin
         volumes:
-          - minio-data:/data  # Mount volume for data persistence
-        options: --health-cmd "curl --silent --fail http://localhost:9000/minio/health/ready" --health-interval 10s --health-timeout 5s --health-retries 5
+          - minio-data:/data
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -26,6 +26,16 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      minio:
+        image: minio/minio:latest
+        env:
+          MINIO_ACCESS_KEY: minioadmin
+          MINIO_SECRET_KEY: minioadmin
+          MINIO_BUCKET: profile-pics  # You can set the bucket name if required
+        ports:
+          - 9000:9000
+        options: --health-cmd "curl --silent --fail http://localhost:9000/minio/health/ready" --health-interval 10s --health-timeout 5s --health-retries 5
+        # Ensure that the MinIO service is healthy before running tests
     steps:
       - uses: actions/checkout@v4
       
@@ -50,6 +60,8 @@ jobs:
       - name: Run tests with Pytest
         env:
           DATABASE_URL: postgresql+asyncpg://user:password@localhost:5432/myappdb  # Configure the DATABASE_URL environment variable for tests
+          MINIO_URL: "http://minio:9000"  # Set the MinIO service URL to communicate with it in the test environment
+
         run: pytest
 
   build-and-push-docker:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -39,7 +39,7 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
-        command: server /data 
+          --entrypoint "sh -c 'minio server /data'"
     steps:
       - uses: actions/checkout@v4
       
@@ -66,7 +66,7 @@ jobs:
           for i in {1..10}; do
             curl -f http://localhost:9000/minio/health/ready && break || sleep 3
           done
-              
+
       - name: Run tests with Pytest
         env:
           minio_host: "localhost:9000"  

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -28,14 +28,19 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       minio:
         image: minio/minio:latest
+        command: server /data --console-address ":9001"  # Starts the MinIO server and console on port 9001
         env:
           MINIO_ACCESS_KEY: minioadmin
           MINIO_SECRET_KEY: minioadmin
-          MINIO_BUCKET: profile-pics  # You can set the bucket name if required
         ports:
-          - 9000:9000
+          - 9000:9000  # MinIO API port
+          - 9001:9001  # MinIO web console port
+        volumes:
+          - minio-data:/data  # Mount volume for data persistence
         options: --health-cmd "curl --silent --fail http://localhost:9000/minio/health/ready" --health-interval 10s --health-timeout 5s --health-retries 5
         # Ensure that the MinIO service is healthy before running tests
+        networks:
+          - app-network
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -33,7 +33,13 @@ jobs:
           MINIO_ROOT_PASSWORD: minioadmin
         ports:
           - 9000:9000
-          - 9001:9001  
+          - 9001:9001
+        options: >-
+          --health-cmd="curl -f http://localhost:9000/minio/health/ready || exit 1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+        command: server /data 
     steps:
       - uses: actions/checkout@v4
       
@@ -54,7 +60,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          
+
+      - name: Wait for MinIO to be ready
+        run: |
+          for i in {1..10}; do
+            curl -f http://localhost:9000/minio/health/ready && break || sleep 3
+          done
+              
       - name: Run tests with Pytest
         env:
           minio_host: "localhost:9000"  

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -57,7 +57,7 @@ jobs:
           
       - name: Run tests with Pytest
         env:
-          # minio_host: "localhost:9000"  
+          minio_host: "localhost:9000"  
           DATABASE_URL: postgresql+asyncpg://user:password@localhost:5432/myappdb  # Configure the DATABASE_URL environment variable for tests
         run: pytest
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -59,9 +59,7 @@ jobs:
       - name: Run tests with Pytest
         env:
           DATABASE_URL: postgresql+asyncpg://user:password@localhost:5432/myappdb  # Configure the DATABASE_URL environment variable for tests
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin
-          MINIO_URL: "http://minio:9000"  # Set the MinIO service URL to communicate with it in the test environment
+          MINIO_URL: "http://localhost:9000"  # Set the MinIO service URL to communicate with it in the test environment
 
         run: pytest
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -34,7 +34,6 @@ jobs:
         ports:
           - 9000:9000
           - 9001:9001  
-        options: --health-cmd "curl --silent --fail http://localhost:9000/minio/health/live" --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v4
       
@@ -60,7 +59,6 @@ jobs:
         env:
           minio_host: "http://localhost:9000"  
           DATABASE_URL: postgresql+asyncpg://user:password@localhost:5432/myappdb  # Configure the DATABASE_URL environment variable for tests
-
         run: pytest
 
   build-and-push-docker:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -27,7 +27,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       minio:
-        image: lazybit/minio
+        image: minio/minio
         env:
           MINIO_ROOT_USER: minioadmin
           MINIO_ROOT_PASSWORD: minioadmin
@@ -58,8 +58,8 @@ jobs:
           
       - name: Run tests with Pytest
         env:
+          minio_host: "http://localhost:9000"  
           DATABASE_URL: postgresql+asyncpg://user:password@localhost:5432/myappdb  # Configure the DATABASE_URL environment variable for tests
-          MINIO_URL: "http://localhost:9000"  # Set the MinIO service URL to communicate with it in the test environment
 
         run: pytest
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -34,6 +34,8 @@ jobs:
         ports:
           - 9000:9000
           - 9001:9001  
+        options: --health-cmd="curl --silent --fail http://localhost:9000/minio/health/live"  # Health check using liveness probe
+
     steps:
       - uses: actions/checkout@v4
       
@@ -57,7 +59,7 @@ jobs:
           
       - name: Run tests with Pytest
         env:
-          minio_host: "http://localhost:9000"  
+          minio_host: "localhost:9000"  
           DATABASE_URL: postgresql+asyncpg://user:password@localhost:5432/myappdb  # Configure the DATABASE_URL environment variable for tests
         run: pytest
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -27,7 +27,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       minio:
-        image: minio/minio:latest
+        image: lazybit/minio
         env:
           MINIO_ROOT_USER: minioadmin
           MINIO_ROOT_PASSWORD: minioadmin

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -70,6 +70,11 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://user:password@localhost:5432/myappdb  # Configure the DATABASE_URL environment variable for tests
         run: pytest
 
+      - name: Stop and remove MinIO # since we added it manually
+        if: always()
+        run: |
+          docker stop minio || true
+          docker rm minio || true
   build-and-push-docker:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -26,20 +26,7 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-      minio:
-        image: minio/minio
-        env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin
-        ports:
-          - 9000:9000
-          - 9001:9001
-        options: >-
-          --health-cmd="curl -f http://localhost:9000/minio/health/ready || exit 1"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-          --entrypoint "sh -c 'minio server /data'"
+
     steps:
       - uses: actions/checkout@v4
       
@@ -60,6 +47,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+
+      - name: Start MinIO manually
+        run: |
+          docker run -d \
+            -p 9000:9000 \
+            -p 9001:9001 \
+            --name minio \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio server /data
 
       - name: Wait for MinIO to be ready
         run: |

--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -252,9 +252,9 @@ async def upload_profile_pic(user_id: UUID,  request: Request, file: UploadFile 
     user = await UserService.get_by_id(db, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
+    
 
     profile_picture_url = await minio_service.upload_profile_picture(user, file, db)
-    # user.profile_picture_url = profile_picture_url
-    # await db.commit()
+
     return {"profile_picture_url": profile_picture_url}
 

--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -252,8 +252,10 @@ async def upload_profile_pic(user_id: UUID,  request: Request, file: UploadFile 
     user = await UserService.get_by_id(db, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
-    
 
+    ALLOWED_CONTENT_TYPES = ["image/jpeg", "image/png", "image/jpg"]
+    if file.content_type not in ALLOWED_CONTENT_TYPES:
+        raise HTTPException(status_code=400,detail=f"Invalid file type. Only JPEG, JPG or PNG are allowed. Please choose different file type")
     profile_picture_url = await minio_service.upload_profile_picture(user, file, db)
 
     return {"profile_picture_url": profile_picture_url}

--- a/app/services/minio_service.py
+++ b/app/services/minio_service.py
@@ -23,10 +23,6 @@ class MinioService:
         extension = file.filename.split('.')[-1]
         fileName = f"{uuid.uuid4()}.{extension}"
         content = await file.read()
-
-        ALLOWED_CONTENT_TYPES = ["image/jpeg", "image/png", "image/jpg"]
-        if file.content_type not in ALLOWED_CONTENT_TYPES:
-            raise HTTPException(status_code=400,detail=f"Invalid file type. Only JPEG, JPG or PNG are allowed. Please choose different file type")
     
         if not self.minio_client.bucket_exists(self.bucket_name):
             self.minio_client.make_bucket(self.bucket_name)

--- a/app/services/minio_service.py
+++ b/app/services/minio_service.py
@@ -1,4 +1,5 @@
 # minio_service.py
+from http.client import HTTPException
 import io
 import uuid
 from minio import Minio
@@ -23,6 +24,10 @@ class MinioService:
         fileName = f"{uuid.uuid4()}.{extension}"
         content = await file.read()
 
+        ALLOWED_CONTENT_TYPES = ["image/jpeg", "image/png", "image/jpg"]
+        if file.content_type not in ALLOWED_CONTENT_TYPES:
+            raise HTTPException(status_code=400,detail=f"Invalid file type. Only JPEG, JPG or PNG are allowed. Please choose different file type")
+    
         if not self.minio_client.bucket_exists(self.bucket_name):
             self.minio_client.make_bucket(self.bucket_name)
 


### PR DESCRIPTION
Fixes to allow only image files to be sent over the API endpoint